### PR TITLE
Add vue-toast-notification package and usage in Login.vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19059,6 +19059,11 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "vue-toast-notification": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/vue-toast-notification/-/vue-toast-notification-0.5.4.tgz",
+      "integrity": "sha512-TzsvFJ2rYK+EP/b95Gl4Prs4ClaspPZgpotkTzVqin/6p420TDVR/1giSTFfV8WFtHwWPf/cBe0nKTMwhxzJag=="
+    },
     "watchpack": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@schirrel/request": "^1.2.0",
     "@schirrel/api-request": "^1.0.4",
+    "@schirrel/request": "^1.2.0",
     "milligram": "^1.3.0",
     "vue": "2.6.11",
     "vue-js-modal": "^1.3.31",
     "vue-modal-dialogs": "^3.0.0",
-    "vue-router": "3.1.3"
+    "vue-router": "3.1.3",
+    "vue-toast-notification": "^0.5.4"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,13 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue'
+import VueToast from 'vue-toast-notification';
+import 'vue-toast-notification/dist/theme-default.css';
 import App from './App'
 import router from './router'
 Vue.config.productionTip = false
+
+Vue.use(VueToast);
 
 // new Vue({
 //   el: '#app',

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -29,6 +29,7 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import Auth from '../services/Auth';
     export default {
         name: 'Login',
@@ -42,6 +43,7 @@ import Auth from '../services/Auth';
         },
         methods: {
             doLogin : function(evt) {
+                Vue.$toast.success('Login realizado com sucesso');
                 Auth.login(this.auth, ()=>{
                     this.$router.push('/')
                 })


### PR DESCRIPTION
This PR adds the vue-toast-notification package, configures it using the default theme and adds example usage to the login screen.

Example of the package working in the login screen:
![vue toast in login](https://user-images.githubusercontent.com/51180770/94993354-cb448300-0566-11eb-9824-4b546096afb4.gif)
